### PR TITLE
UE 5.0 Support

### DIFF
--- a/VertexAnimToolset/Source/VertexAnimToolsetEditor/Private/VertexAnimToolsetEditor.cpp
+++ b/VertexAnimToolset/Source/VertexAnimToolsetEditor/Private/VertexAnimToolsetEditor.cpp
@@ -36,7 +36,7 @@
 #include "Developer/AssetTools/Public/IAssetTools.h"
 #include "Developer/AssetTools/Public/AssetToolsModule.h"
 
-#include "Toolkits/AssetEditorManager.h"
+#include "Toolkits/ToolkitManager.h"
 #include "Dialogs/DlgPickAssetPath.h"
 #include "AssetRegistryModule.h"
 

--- a/VertexAnimToolset/VertexAnimToolset.uplugin
+++ b/VertexAnimToolset/VertexAnimToolset.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "https://github.com/Rexocrates/Vertex_Anim_Toolset/blob/main/Vertex%20Anim%20Toolset%20Documentation.pdf",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/d998b22372a44975b312e85cf663bbab",
 	"SupportURL": "https://github.com/Rexocrates/Vertex_Anim_Toolset/issues",
-	"EngineVersion": "4.26.0",
+	"EngineVersion": "5.0.0",
 	"CanContainContent": true,
 	"Installed": true,
 	"Modules": [


### PR DESCRIPTION
TODO: Before Finished:
- Mesh UV Channel 1 is not generated correctly yet. They seem to be skewed towards X-0 more than they should be. 

> Update to UE 5.0
> Many various data types had to be changed to be single-floating precision versions. Because UE5 uses double by default now. But not all of its APIs are updated. So interfacing with the old APIs that use float still required changing our types to use the non-standard Vectors, Quats, Matrix. 